### PR TITLE
Annulation de "Correction de bug si Altis-Pan est installé derrière un reverse proxy"

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -80,7 +80,7 @@
                 <div id="fh5co-navbar" class="navbar-collapse collapse">
                     <ul class="nav navbar-nav navbar-right">
                         <li <?php if (Request::is('home') OR Request::is('/')) { echo 'class="active"'; } ?>>
-                            <a href="{{ url('/') }}/"><span><i class="fa fa-home"></i> Accueil<span class="border"></span></span></a>
+                            <a href="{{ url('/') }}"><span><i class="fa fa-home"></i> Accueil<span class="border"></span></span></a>
                         </li>
 
                         <li class="{{ Request::is('news') ? 'active' : '' }} <?php $path = Route::getCurrentRoute()->getPath(); if (starts_with($path, 'news/')) echo "active"; ?>">


### PR DESCRIPTION
Ceci annule le commit 995e7246cb6d9f7f307c602ffe5253b5a88479bc.
En effet, le bug venait d'Apache et de la configuration derrière un reverse proxy. Donc si jamais AltisPan est installé sur un Apache situé derrière un reverse proxy, il faut soit: mettre le DocumentRoot du VirtualHost Apache vers le dossier "public" d'AltisPan soit faire en sorte que le reverse proxy redirige http://<addresse du serveur>/<éventuel dossier d'installation>/public vers http://<addresse du serveur>/<éventuel dossier d'installation>/public/ afin qu'Apache n'ait pas à le faire (sinon ce dernier fait ça n'importe comment).